### PR TITLE
Add publishing set up with Mono

### DIFF
--- a/.changesets/initial-release.md
+++ b/.changesets/initial-release.md
@@ -1,0 +1,6 @@
+---
+bump: major
+type: add
+---
+
+The first release of the AppSignal MCP Server as a npm package.

--- a/.github/workflows/create_release_from_tag.yml
+++ b/.github/workflows/create_release_from_tag.yml
@@ -1,0 +1,62 @@
+name: "Create release from tag"
+
+on:
+  push:
+    tags:
+      - "v**"
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  release:
+    name: "Create release"
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_NAME: "MCP Server"
+      CHANGELOG_CATEGORY: "App"
+      CHANGELOG_LINK: "https://github.com/appsignal/appsignal-mcp/blob/main/CHANGELOG.md"
+    steps:
+      - name: Checkout repository at tag
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ github.ref }}"
+
+      - name: Get tag name
+        run: |
+          echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Get changelog contents from tag
+        run: |
+          # Use sed to remove everything after "-----BEGIN PGP SIGNATURE-----" if it's present
+          # and also always remove the last line of the git show output
+          git show --format=oneline --no-color --no-patch "${{ env.TAG_NAME }}" \
+          | sed '1,2d' \
+          | sed '$d' \
+          | sed '/-----BEGIN PGP SIGNATURE-----/,$d' \
+          > CHANGELOG_TEXT.txt
+
+          echo "" >> CHANGELOG_TEXT.txt
+          echo "" >> CHANGELOG_TEXT.txt
+
+          TAG_NAME_FOR_LINK=$(echo "${{ env.TAG_NAME }}" | sed 's/^v//' | tr -d '.')
+          echo "View the [$PACKAGE_NAME ${{ env.TAG_NAME }} changelog]($CHANGELOG_LINK#$TAG_NAME_FOR_LINK) for more information." >> CHANGELOG_TEXT.txt
+
+      - name: Submit changelog entry
+        run: |
+          # Prepare JSON payload using jq to ensure proper escaping
+          payload=$(jq -n \
+            --arg title "$PACKAGE_NAME ${{ env.TAG_NAME }}" \
+            --arg category "$CHANGELOG_CATEGORY" \
+            --arg version "$(echo "${{ env.TAG_NAME }}" | sed 's/^v//')" \
+            --arg changelog "$(cat CHANGELOG_TEXT.txt)" \
+            --arg assignee "${{ github.actor }}" \
+            '{ref: "main", inputs: {title: $title, category: $category, version: $version, changelog: $changelog, assignee: $assignee}}')
+
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.INTEGRATIONS_CHANGELOG_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            --fail-with-body \
+            https://api.github.com/repos/appsignal/appsignal.com/actions/workflows/102125282/dispatches \
+            -d "$payload"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# AppSignal MCP Server

--- a/README.md
+++ b/README.md
@@ -145,6 +145,29 @@ To work on the MCP server:
    npm run inspector
    ```
 
+### Change management
+
+Every change that will results in a new version to be released, requires a changeset.
+Changesets are small Markdown file that describe the change for the end-user.
+The changeset's frontmatter describes the type of change (new feature, bug fix, etc.) and the version bump (major, minor, or patch).
+
+Use [Mono's changeset CLI](https://github.com/appsignal/mono/?tab=readme-ov-file#changeset-add) to generate a new changeset file.
+Commit the changeset file and include it in your Pull Requests.
+
+```
+mono changeset add
+```
+
+### Publishing
+
+Install [Mono](https://github.com/appsignal/mono/), the tool used for release management.
+
+```
+git pull # Ensure you have the latest version
+
+mono publish # Publish a new version
+```
+
 ## Contributing
 
 Thinking of contributing to our project? Awesome! 🚀

--- a/mono.yml
+++ b/mono.yml
@@ -1,0 +1,6 @@
+---
+language: nodejs
+repo: "https://github.com/appsignal/appsignal-mcp"
+npm_client: "npm"
+git-commit:
+  pre: "npm install"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appsignal-mcp",
   "author": "AppSignal",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "The official AppSignal MCP server",
   "homepage": "https://appsignal.com",
   "license": "MIT",


### PR DESCRIPTION
## Add mono configuration for publishing

Add a `mono.yml` configuration file so that it works with Mono. https://github.com/appsignal/mono/

Use changesets to generate changesets and bump the version number. See the Mono README for more information.

I dropped the committed version down to 0.1.0 and added a changeset for a major version bump so the next version will be version 1.0.0 on npm.

Part of #33

## Add GitHub workflow for changelog PR generation

With this workflow, when a new Git tag is pushed, we automatically create a Pull Request on the appsignal.com/changelog page.
