### PR TITLE
Fix mcp server docs link due to the Mintlify docs having its own MCP path reserved

### DIFF
--- a/.changesets/fix-mcp-server-docs-link.md
+++ b/.changesets/fix-mcp-server-docs-link.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix the documentation link in the README to point to the correct MCP server docs path.

--- a/.changesets/fix-mcp-server-docs-link.md
+++ b/.changesets/fix-mcp-server-docs-link.md
@@ -1,6 +1,0 @@
----
-bump: patch
-type: fix
----
-
-Fix the documentation link in the README to point to the correct MCP server docs path.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the official [AppSignal](https://www.appsignal.com/tour/mcp-server) [MCP
 
 
 
-This feature is in *Beta*. Documentation can also be found [here](https://docs.appsignal.com/mcp) 
+This feature is in *Beta*. Documentation can also be found [here](https://docs.appsignal.com/mcp-server) 
 
 Join our [Discord community][discord] to help shape this MCP implementation. Feature requests are welcome! 
 


### PR DESCRIPTION
Fix mcp server docs link due to the Mintlify docs having its own MCP reserved path at [docs.appsignal.com/mcp](https://docs.appsignal.com), which cannot be changed or renamed.
If not fixed, it will return a document like this instead of our docs:
<img width="1669" height="1029" alt="image" src="https://github.com/user-attachments/assets/8d2b001d-a028-4870-9342-a5886aa8becc" />

- Docs fix already merged:

https://github.com/appsignal/appsignal-docs/pull/11

- Full thread with details is here:
https://appsignal.slack.com/archives/C0DTGLNGN/p1781191140909759

If this PR gets approved, I'll also need to change the About link:
<img width="689" height="241" alt="image" src="https://github.com/user-attachments/assets/8a75a891-8a38-4761-a5f2-097b09e8e010" />
